### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/197/545/421197545.geojson
+++ b/data/421/197/545/421197545.geojson
@@ -318,6 +318,9 @@
     },
     "wof:country":"SH",
     "wof:created":1459009917,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a9b1b350532bf5a98728cdcf3a3cb714",
     "wof:hierarchy":[
         {
@@ -330,7 +333,7 @@
         }
     ],
     "wof:id":421197545,
-    "wof:lastmodified":1566644296,
+    "wof:lastmodified":1582356318,
     "wof:name":"Jamestown",
     "wof:parent_id":85677067,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.