### PR TITLE
sh concordances, placetype local, and more

### DIFF
--- a/data/856/770/63/85677063.geojson
+++ b/data/856/770/63/85677063.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007291,
-    "geom:area_square_m":89291178.712843,
+    "geom:area_square_m":89291608.879756,
     "geom:bbox":"-14.417714,-7.979669,-14.294789,-7.877862",
     "geom:latitude":-7.935453,
     "geom:longitude":-14.363945,
@@ -195,12 +195,14 @@
         "gn:id":2411430,
         "gp:id":20069822,
         "hasc:id":"SH.AC",
+        "iso:code":"SH-AC",
         "iso:id":"SH-AC",
         "qs_pg:id":307857,
         "unlc:id":"SH-AC"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SH",
-    "wof:geomhash":"e80f135c22b5ec61eca7d258996e2443",
+    "wof:geomhash":"6d51bdd5190a114565936b9a69ae3e7f",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -217,7 +219,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636502603,
+    "wof:lastmodified":1695884937,
     "wof:name":"Ascension",
     "wof:parent_id":85632485,
     "wof:placetype":"region",

--- a/data/856/770/67/85677067.geojson
+++ b/data/856/770/67/85677067.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010545,
-    "geom:area_square_m":125365915.156754,
+    "geom:area_square_m":125365579.738462,
     "geom:bbox":"-5.78954,-16.01572,-5.65038,-15.902114",
     "geom:latitude":-15.959098,
     "geom:longitude":-5.717364,
@@ -557,13 +557,15 @@
         "gn:id":6930057,
         "gp:id":20069824,
         "hasc:id":"SH.SH",
+        "iso:code":"SH-HL",
         "iso:id":"SH-HL",
         "qs_pg:id":312270,
         "wd:id":"Q34497",
         "wk:page":"Saint Helena"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SH",
-    "wof:geomhash":"524eeb5a9fce821d59250a4cba50e7f5",
+    "wof:geomhash":"6f517e50079bd73b3bd3fd5537fbd387",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -580,7 +582,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690863643,
+    "wof:lastmodified":1695884327,
     "wof:name":"Saint Helena",
     "wof:parent_id":85632485,
     "wof:placetype":"region",

--- a/data/856/770/71/85677071.geojson
+++ b/data/856/770/71/85677071.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01583,
-    "geom:area_square_m":152716434.372372,
+    "geom:area_square_m":152716756.137584,
     "geom:bbox":"-12.335317,-40.397882,-9.895375,-37.055759",
     "geom:latitude":-38.69329,
     "geom:longitude":-11.13726,
@@ -436,13 +436,15 @@
         "gn:id":3370684,
         "gp:id":20069823,
         "hasc:id":"SH.TA",
+        "iso:code":"SH-TA",
         "iso:id":"SH-TA",
         "qs_pg:id":894233,
         "unlc:id":"SH-TA",
         "wd:id":"Q220982"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SH",
-    "wof:geomhash":"05f8ddbf5d1112486f7d605ef1ca5d9e",
+    "wof:geomhash":"40a5be837289b08e215c484736dc42bb",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -457,7 +459,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690863643,
+    "wof:lastmodified":1695884937,
     "wof:name":"Tristan da Cunha",
     "wof:parent_id":-1,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.